### PR TITLE
Allow `v` in TRAVIS_TAG

### DIFF
--- a/helpers/setVersion.ts
+++ b/helpers/setVersion.ts
@@ -11,11 +11,24 @@ import { trim } from 'lodash';
  * The script sets `version` key in `package.json` during deployment to the
  * value of `TRAVIS_TAG`. That way we don't have to remember to set the version
  * key in `package.json` before publishing.
+ *
+ * If `TRAVIS_TAG` starts with a `v` such as `v4.0.2`, this script will strip out the `v`
+ * to make `TRAVIS_TAG` semver-compatible.
  */
+function getVersion() {
+  const version = trim(process.env.TRAVIS_TAG);
+
+  if (version[0] === 'v') {
+    return version.substr(1);
+  }
+
+  return version;
+}
+
 async function setVersion() {
   const packagejsonPath = path.resolve(process.cwd(), 'package.json');
   const packageJson = require(packagejsonPath); // tslint:disable-line no-require-imports non-literal-require
-  const version = trim(process.env.TRAVIS_TAG);
+  const version = getVersion();
 
   if (version) {
     await writeJsonFile(packagejsonPath, { ...packageJson, version });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26730388/38224829-9d7b93d2-36a6-11e8-9646-afbe7944d3e6.png)

GitHub shows versions with letters before ones without letters, which is annoying when you're trying to see the latest version in order to set the next one. So I modified the `setVersion` script to allow git tags that start with `v`. It simply removes the `v` and sets the version to `package.json`